### PR TITLE
v1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 1.0.7
+
+- `PCanvasFlutter`:
+  - Added `setPixels`.
+  - Added support for `clip`.
+  - Added support for `transform` (translation).
+- Added `PCanvasFactoryFlutter`.
+  - `pixelsToPNG` using package `image` instead of an internal Flutter Canvas. 
+- `PCanvasWidgetPainter`:
+  - `addOpAsync`: to allow operations that need asynchronous resolution.
+- pcanvas: ^1.0.7
+- image: ^4.0.7
+
+* Sync version number with `pcanvas` package...
+
 ## 1.0.2
 
 - Added support to stroke/fill circle.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - `pixelsToPNG` using package `image` instead of an internal Flutter Canvas. 
 - `PCanvasWidgetPainter`:
   - `addOpAsync`: to allow operations that need asynchronous resolution.
+- Fix GitHub Dart CI badge.
 - pcanvas: ^1.0.7
 - image: ^4.0.7
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/pcanvas_flutter.svg?logo=dart&logoColor=00b9fc)](https://pub.dev/packages/pcanvas_flutter)
 [![Null Safety](https://img.shields.io/badge/null-safety-brightgreen)](https://dart.dev/null-safety)
-[![CI](https://img.shields.io/github/workflow/status/gmpassos/pcanvas_flutter/Dart%20CI/master?logo=github-actions&logoColor=white)](https://github.com/gmpassos/pcanvas_flutter/actions)
+[![Dart CI](https://github.com/gmpassos/pcanvas_flutter/actions/workflows/dart.yml/badge.svg?branch=master)](https://github.com/gmpassos/pcanvas_flutter/actions/workflows/dart.yml)
 [![GitHub Tag](https://img.shields.io/github/v/tag/gmpassos/pcanvas_flutter?logo=git&logoColor=white)](https://github.com/gmpassos/pcanvas_flutter/releases)
 [![New Commits](https://img.shields.io/github/commits-since/gmpassos/pcanvas_flutter/latest?logo=git&logoColor=white)](https://github.com/gmpassos/pcanvas_flutter/network)
 [![Last Commits](https://img.shields.io/github/last-commit/gmpassos/pcanvas_flutter?logo=git&logoColor=white)](https://github.com/gmpassos/pcanvas_flutter/commits/master)

--- a/example/build/flutter_assets/NOTICES
+++ b/example/build/flutter_assets/NOTICES
@@ -11522,7 +11522,7 @@ image
 
 The MIT License
 
-Copyright (c) 2013-2021 Brendan Duncan.
+Copyright (c) 2013-2022 Brendan Duncan.
 All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:pcanvas_flutter/pcanvas_flutter.dart';
+import 'package:collection/collection.dart';
 
 void main() {
   runApp(const MyApp());
@@ -45,6 +46,37 @@ class MyCanvasPainter extends PCanvasPainter {
     }
 
     pCanvas.log('** Loaded images!');
+
+    {
+      var panel = PCanvasPanel2D(
+          height: 100,
+          width: 200,
+          pos: const Point(100, 100),
+          zIndex: 999999,
+          style: PStyle(color: PColor.colorWhite.copyWith(alpha: 0.50)));
+
+      panel.addElement(PRectangleElement(
+          style: PColor.colorRed.toStyle(),
+          pos: const Point(10, 20),
+          width: 20,
+          height: 10));
+
+      var panel2 = PCanvasPanel2D(
+          height: 50,
+          width: 100,
+          pos: const Point(20, 10),
+          style: PStyle(color: PColor.colorGrey.copyWith(alpha: 0.50)));
+
+      panel2.addElement(PRectangleElement(
+          style: PColor.colorBlue.toStyle(),
+          pos: const Point(5, 10),
+          width: 10,
+          height: 5));
+
+      panel.addElement(panel2);
+
+      pCanvas.addElement(panel);
+    }
 
     return true;
   }
@@ -143,14 +175,62 @@ class MyCanvasPainter extends PCanvasPainter {
     pCanvas?.log(event);
   }
 
+  int _stepCount = 0;
+
   @override
   void onKeyDown(PCanvasKeyEvent event) {
+    var pCanvas = this.pCanvas!;
+
     var s = event.code?.toLowerCase() == 'enter' ? '\n' : (event.key ?? '');
 
     textExtra += s;
 
+    var keyCode = event.code?.toLowerCase() ?? '';
+    var key = event.key?.toLowerCase() ?? '';
+
+    var step = 0;
+
+    if (keyCode.contains('right') || key == 'd') {
+      if (_stepCount <= 0) {
+        _stepCount = 1;
+      } else {
+        _stepCount++;
+      }
+
+      step = _stepCount.clamp(1, 30);
+    } else if (keyCode.contains('left') || key == 'a') {
+      if (_stepCount >= 0) {
+        _stepCount = -1;
+      } else {
+        _stepCount--;
+      }
+
+      step = _stepCount.clamp(-30, -1);
+    }
+
+    {
+      var rectElem1 = pCanvas
+          .selectElementByType<PCanvasPanel2D>()
+          .firstOrNull
+          ?.selectElementByType<PRectangleElement>()
+          .firstOrNull;
+
+      var rectElem2 = pCanvas
+          .selectElementByType<PCanvasPanel2D>()
+          .firstOrNull
+          ?.selectElementByType<PCanvasPanel2D>()
+          .firstOrNull
+          ?.selectElementByType<PRectangleElement>()
+          .firstOrNull;
+
+      rectElem1?.position = rectElem1.position.incrementX(step);
+      rectElem2?.position = rectElem2.position.incrementX(step ~/ 2);
+
+      refresh();
+    }
+
     refresh();
 
-    pCanvas?.log(event);
+    pCanvas.log(event);
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -37,7 +37,7 @@ packages:
     source: hosted
     version: "1.1.1"
   collection:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: collection
       url: "https://pub.dartlang.org"
@@ -108,7 +108,7 @@ packages:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.2"
+    version: "4.0.7"
   js:
     dependency: transitive
     description:
@@ -157,14 +157,14 @@ packages:
       name: pcanvas
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.0.7"
   pcanvas_flutter:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "1.0.2"
+    version: "1.0.7"
   petitparser:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   cupertino_icons: ^1.0.2
   pcanvas: ^1.0.5
   pcanvas_flutter: ^1.0.2
+  collection: ^1.16.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -96,12 +96,12 @@ packages:
     source: hosted
     version: "4.0.2"
   image:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.2"
+    version: "4.0.7"
   js:
     dependency: transitive
     description:
@@ -150,7 +150,7 @@ packages:
       name: pcanvas
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.0.7"
   petitparser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pcanvas_flutter
 description: Flutter implementation of `PCanvas` for the package `pcanvas`.
-version: 1.0.2
+version: 1.0.7
 homepage: https://github.com/gmpassos/pcanvas_flutter
 
 environment:
@@ -10,7 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  pcanvas: ^1.0.5
+  pcanvas: ^1.0.7
+  image: ^4.0.7
 
 dev_dependencies:
   flutter_test:
@@ -20,3 +21,4 @@ dev_dependencies:
 #dependency_overrides:
 #  pcanvas:
 #    path: ../pcanvas
+


### PR DESCRIPTION
- `PCanvasFlutter`:
  - Added `setPixels`.
  - Added support for `clip`.
  - Added support for `transform` (translation).
- Added `PCanvasFactoryFlutter`.
  - `pixelsToPNG` using package `image` instead of an internal Flutter Canvas.
- `PCanvasWidgetPainter`:
  - `addOpAsync`: to allow operations that need asynchronous resolution.
- pcanvas: ^1.0.7
- image: ^4.0.7

* Sync version number with `pcanvas` package...